### PR TITLE
security: add fuzzing coverage and document remaining code-scanning alerts

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,12 @@
+# Contributors
+
+## Human Maintainers and Contributors
+
+- [@rockywuest](https://github.com/rockywuest)
+
+## AI-Assisted Contributions
+
+- OpenAI Codex (AI coding assistant used by the maintainer for implementation support)
+
+Note: AI assistants do not have a GitHub user identity in this repository.
+Commits and pull requests are attributed to the authenticated maintainer account.

--- a/README.md
+++ b/README.md
@@ -212,9 +212,11 @@ Architecture and roadmap:
 - Maintainers: see `MAINTAINERS.md`
 - Support: see `SUPPORT.md`
 - Changelog: see `CHANGELOG.md`
+- Contributors: see `CONTRIBUTORS.md`
 - Community operations: see `docs/COMMUNITY_PLAYBOOK.md`
 - Maintainer runbook: see `docs/MAINTAINER_RUNBOOK.md`
 - Security reporting: see `SECURITY.md`
+- Security code-scanning status: see `docs/SECURITY_CODE_SCANNING_STATUS.md`
 
 ## License
 

--- a/docs/SECURITY_CODE_SCANNING_STATUS.md
+++ b/docs/SECURITY_CODE_SCANNING_STATUS.md
@@ -1,0 +1,27 @@
+# Security Code Scanning Status
+
+Last updated: February 22, 2026
+
+## Current open items from GitHub code scanning
+
+1. `CodeReviewID` (high)
+   - Status: open
+   - Why open: Scorecard reports not enough merged changesets with review approvals in repository history.
+   - What closes it: merge upcoming changes via pull requests with explicit approvals from another reviewer account.
+
+2. `FuzzingID` (medium)
+   - Status: mitigation implemented
+   - Change made: property-based fuzz tests added with `fast-check` in `src/utils/inputValidation.fuzz.test.ts`.
+   - Expected result: alert closes after the next Scorecard analysis run on `main`.
+
+3. `CIIBestPracticesID` (low)
+   - Status: open
+   - Why open: no OpenSSF Best Practices badge project entry exists yet for this repository.
+   - What closes it: register the project at [bestpractices.dev](https://www.bestpractices.dev/projects/new) and add the badge to `README.md`.
+
+## Maintainer checklist to close the remaining open items
+
+1. Add at least one trusted second reviewer account (or collaborator).
+2. Enforce review-first merges for all feature/security pull requests.
+3. Register this repository on OpenSSF Best Practices and add badge link in the README.
+4. Re-run Scorecard workflow and confirm all related alerts are closed.

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,6 +76,7 @@
         "eslint": "^9.9.0",
         "eslint-plugin-react-hooks": "^5.1.0-rc.0",
         "eslint-plugin-react-refresh": "^0.4.9",
+        "fast-check": "^4.5.3",
         "globals": "^15.9.0",
         "jsdom": "^28.1.0",
         "postcss": "^8.4.47",
@@ -5406,6 +5407,29 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/fast-check": {
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.5.3.tgz",
+      "integrity": "sha512-IE9csY7lnhxBnA8g/WI5eg/hygA6MGWJMSNfFRrBlXUciADEhS1EDB0SIsMSvzubzIlOBbVITSsypCsW717poA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -6644,6 +6668,23 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-7.0.1.tgz",
+      "integrity": "sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "eslint": "^9.9.0",
     "eslint-plugin-react-hooks": "^5.1.0-rc.0",
     "eslint-plugin-react-refresh": "^0.4.9",
+    "fast-check": "^4.5.3",
     "globals": "^15.9.0",
     "jsdom": "^28.1.0",
     "postcss": "^8.4.47",

--- a/src/utils/inputValidation.fuzz.test.ts
+++ b/src/utils/inputValidation.fuzz.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import fc from "fast-check";
+import { InputValidator } from "./inputValidation";
+
+describe("InputValidator fuzz tests", () => {
+  it("rejects suspicious argument content across random inputs", () => {
+    const suspiciousToken = fc.constantFrom(
+      "<script>alert(1)</script>",
+      "javascript:alert(1)",
+      "onload=alert(1)",
+      "data:text/html,<b>x</b>",
+      "vbscript:msgbox(1)",
+    );
+
+    fc.assert(
+      fc.property(fc.string(), suspiciousToken, fc.string(), (prefix, token, suffix) => {
+        const result = InputValidator.validateAndSanitizeArgument(`${prefix}${token}${suffix}`);
+
+        expect(result.isValid).toBe(false);
+        expect(result.errors.some((message) => message.includes("nicht erlaubte Inhalte"))).toBe(true);
+      }),
+      { numRuns: 100 },
+    );
+  });
+
+  it("flags overlong arguments for random long strings", () => {
+    fc.assert(
+      fc.property(fc.string({ minLength: 2001, maxLength: 5000 }), (value) => {
+        const result = InputValidator.validateAndSanitizeArgument(value);
+        expect(result.isValid).toBe(false);
+        expect(result.errors.some((message) => message.includes("max. 2000"))).toBe(true);
+      }),
+      { numRuns: 50 },
+    );
+  });
+
+  it("only accepts http and https source URLs", () => {
+    const domain = fc.constantFrom("example.com", "sub.domain.org", "test.dev");
+
+    fc.assert(
+      fc.property(
+        fc.constantFrom("ftp", "file", "javascript", "data", "ws"),
+        domain,
+        (protocol, domain) => {
+          const result = InputValidator.validateSourceUrl(`${protocol}://${domain}/path`);
+          expect(result.isValid).toBe(false);
+          expect(result.errors.some((message) => message.includes("HTTP/HTTPS"))).toBe(true);
+        },
+      ),
+      { numRuns: 50 },
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add property-based fuzz tests for input validation with fast-check
- add CONTRIBUTORS.md with explicit AI-assisted contribution attribution
- add docs/SECURITY_CODE_SCANNING_STATUS.md with current status and closure path for open Scorecard items
- link contributors and code-scanning status docs from README

## Validation
- npm run check
