### PR TITLE
fix(security): patch vite vulnerability findings from scorecard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -83,7 +83,7 @@
         "tailwindcss": "^3.4.11",
         "typescript": "^5.9.3",
         "typescript-eslint": "^8.58.0",
-        "vite": "^7.3.1",
+        "vite": "^7.3.2",
         "vitest": "^4.1.2"
       }
     },
@@ -7613,9 +7613,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
       "peer": true,

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "tailwindcss": "^3.4.11",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.58.0",
-    "vite": "^7.3.1",
+    "vite": "^7.3.2",
     "vitest": "^4.1.2"
   },
   "overrides": {


### PR DESCRIPTION
## Summary
- bump `vite` from `^7.3.1` to `^7.3.2`
- refresh lockfile to pick patched Vite release

## Why
GitHub code scanning reported `VulnerabilitiesID` with:
- GHSA-4w7w-66w2-5vf9
- GHSA-p9ff-h696-f583
- GHSA-v2wj-q39q-566r

## Validation
- npm run check
- npm audit --json (0 vulnerabilities)
