### PR TITLE
fix(deploy): add vercel.json SPA rewrites

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ test-results
 *.njsproj
 *.sln
 *.sw?
+.vercel

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/index.html" }
+  ]
+}


### PR DESCRIPTION
## Problem

After today's first Vercel deploy, every client-side route returns Vercel's own HTTP 404 instead of being served by the SPA:

\`\`\`
$ curl -I https://debate-wise-app.vercel.app/debates    # 404
$ curl -I https://debate-wise-app.vercel.app/auth       # 404
$ curl -I https://debate-wise-app.vercel.app/anything   # 404
\`\`\`

Only \`/\` works (because it matches \`dist/index.html\` directly).

## Fix

Add \`vercel.json\` with a catch-all rewrite to \`/index.html\` so react-router-dom gets a chance to handle every path. Static asset responses are unaffected — Vercel matches files first, then applies rewrites.

## Verify after merge + redeploy

- \`curl -fsSL https://debate-wise-app.vercel.app/debates\` → 200
- \`curl -fsSL https://debate-wise-app.vercel.app/this-route-does-not-exist\` → 200 (renders NotFound.tsx with the recovery CTAs from #66)

🤖 Generated with [Claude Code](https://claude.com/claude-code)