### PR TITLE
chore(deploy): remove vercel.json — repo is OSS, not a hosted product

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://openapi.vercel.sh/vercel.json",
-  "rewrites": [
-    { "source": "/(.*)", "destination": "/index.html" }
-  ]
-}


### PR DESCRIPTION
## Why

The repository is positioned as a community OSS project (CONTRIBUTING, MAINTAINERS, GOOD_FIRST_ISSUES, OpenSSF tracking, \`docs/SELF_HOSTING.md\`). A maintainer-run live deploy adds operational cost (env vars, redeploy on every merge, public Supabase exposure) without materially serving the OSS goal.

Users wanting to *try* the app run \`npm run dev\` locally; users wanting to *host* their own deploy follow \`docs/SELF_HOSTING.md\`. The "feel the UI" need is covered separately by issue #36 (demo screenshots in README).

## What changes

- Delete \`vercel.json\` (the SPA-rewrite config from #67).
- After this lands, the maintainer should disconnect Vercel git integration in the Vercel dashboard so future merges don't auto-deploy. The deployment slot at \`debate-wise-app.vercel.app\` can be deleted from the Vercel dashboard if no longer needed.
- \`.gitignore\` already ignores \`.vercel/\` — keeping that line is harmless and helps anyone who later runs \`vercel link\` for their own fork.

## Future "deploy your own"

If we want to keep a one-click path for forks, README can grow a "Deploy your own" section with Vercel/Netlify deploy templates that fork the repo and require the cloner's own credentials — zero operational cost on this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)