### PR TITLE
chore: remove unused zod and @hookform/resolvers deps (closes #77)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@hookform/resolvers": "^3.9.0",
         "@radix-ui/react-accordion": "^1.2.12",
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-aspect-ratio": "^1.1.8",
@@ -55,8 +54,7 @@
         "sonner": "^2.0.7",
         "tailwind-merge": "^2.5.2",
         "tailwindcss-animate": "^1.0.7",
-        "vaul": "^1.1.2",
-        "zod": "^3.23.8"
+        "vaul": "^1.1.2"
       },
       "devDependencies": {
         "@eslint/js": "^9.9.0",
@@ -1193,15 +1191,6 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
       "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
       "license": "MIT"
-    },
-    "node_modules/@hookform/resolvers": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-3.9.0.tgz",
-      "integrity": "sha512-bU0Gr4EepJ/EQsH/IwEzYLsT/PEj5C0ynLQ4m+GSHS+xKH4TfSelhluTgOaoc4kA5s7eCsQbM4wvZLzELmWzUg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react-hook-form": "^7.0.0"
-      }
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
@@ -8183,15 +8172,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/zod": {
-      "version": "3.23.8",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
-      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@hookform/resolvers": "^3.9.0",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-aspect-ratio": "^1.1.8",
@@ -70,8 +69,7 @@
     "sonner": "^2.0.7",
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7",
-    "vaul": "^1.1.2",
-    "zod": "^3.23.8"
+    "vaul": "^1.1.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.0",


### PR DESCRIPTION
## Why

Neither dep is imported anywhere in \`src/\`, \`e2e/\`, \`scripts/\`, or \`supabase/\`. \`src/components/ui/form.tsx\` pulls only from \`react-hook-form\` directly (no resolver wired, no zod schema).

Same dead-shadcn-artifact cleanup pattern as \`calendar.tsx\` in #55 and \`resizable.tsx\` in #74.

## Changes

- Drop \`@hookform/resolvers\` (^3.9.0) from \`dependencies\`
- Drop \`zod\` (^3.23.8) from \`dependencies\`
- Lockfile updated — both deps and their transitive subtrees removed from \`node_modules\`

## Verified

- \`npm run lint\` ✓
- \`npm run typecheck\` ✓
- \`npm run test\` — 29/29
- \`npm run build\` ✓

Closes #77 by replacement (not worth migrating zod 3→4 majors for a dep the codebase doesn't use).

🤖 Generated with [Claude Code](https://claude.com/claude-code)