### PR TITLE
chore(dependabot): ignore eslint-plugin-react-hooks until 7.1.x migration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,13 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      # Pinned at 7.0.1 in package.json. 7.1.x introduces stricter
+      # set-state-in-effect / purity rules that flag 14 existing call
+      # sites; bumping needs its own dedicated PR with those fixes, not
+      # a group sweep. Without this entry Dependabot re-proposes the
+      # bump every Monday via the npm-non-breaking group.
+      - dependency-name: "eslint-plugin-react-hooks"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Why

Dependabot keeps sweeping \`eslint-plugin-react-hooks 7.0.1 → 7.1.x\` into the \`npm-non-breaking\` group every Monday — the group's \`patterns: ["*"]\` + \`types: [minor, patch]\` config picks it up, **even though \`package.json\` pins it at exactly \`7.0.1\`**.

The 7.1.x bump triggers 14 new \`set-state-in-effect\` / \`purity\` lint errors across hooks/pages/components — same class of breakage that #60 fixed for the 5.x → 7.0 transition. Doing that as a "minor" group bump every week is wrong; it needs a dedicated PR with the call-site fixes.

## Fix

Add an explicit \`ignore\` block to the npm ecosystem in \`.github/dependabot.yml\`:

\`\`\`yaml
    ignore:
      - dependency-name: "eslint-plugin-react-hooks"
\`\`\`

Stops Dependabot from re-proposing this every Monday. When ready, the 7.1.x migration becomes a dedicated, scoped PR.

## Pairs with

- \`deps/react-19.2.6-and-types-node\` (this sweep) — keeps react-hooks at 7.0.1 so the durable fix and the immediate cleanup line up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)